### PR TITLE
Fixed 'prettier' NPM script alias to be Windows compliant (resolving glob issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build --debug --mode production --target esNext --clearScreen",
-    "format": "prettier --write '**/*.ts*' '**/*.js*' '**/*.css' '**/*.html'",
+    "format": "prettier --write \"**/*.ts*\" \"**/*.js*\" \"**/*.css\" \"**/*.html\"",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "preview": "vite preview"
   },


### PR DESCRIPTION
- Changed `package.json` to have the corrected `"format"` NPM script alias